### PR TITLE
Add string to fix IMS

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -122,6 +122,9 @@
 
     <!-- Whether or not we should show the option to show battery percentage -->
     <bool name="config_battery_percentage_setting_available">true</bool>
+    
+    <!-- Enable the use of the QNS package for IMS -->
+    <string name="config_qualified_networks_service_package">com.android.qns</string>
 
     <!-- Number of physical SIM slots on the device. This includes both eSIM
     and pSIM slots, and is not necessarily the same as the number of phones/logical modems


### PR DESCRIPTION
The following string name needs to be present for certain IMS components to work correctly. This includes Wi-Fi Calling which currently will not function on cheetah and panther.